### PR TITLE
Manually configure root logger

### DIFF
--- a/socketshark/__init__.py
+++ b/socketshark/__init__.py
@@ -202,6 +202,7 @@ def run(context, config):
     backend = load_backend(config_obj)
 
     log_config = config_obj['LOG']
+
     # Configure root logger if logging level is specified in config
     if log_config['level']:
         level = getattr(logging, log_config['level'])
@@ -211,7 +212,9 @@ def run(context, config):
         sh = logging.StreamHandler()
         sh.setFormatter(formatter)
         logger.addHandler(sh)
-    setup_structlog(sys.stdout.isatty())
+
+    if log_config['setup_structlog']:
+        setup_structlog(sys.stdout.isatty())
 
     shark = SocketShark(config_obj)
     backend.run(shark)

--- a/socketshark/config_defaults.py
+++ b/socketshark/config_defaults.py
@@ -5,7 +5,8 @@ BACKEND = 'websockets'
 
 # Logging config
 LOG = {
-    'level': 'INFO',
+    'setup_structlog': True,
+    'level': 'INFO',  # Set to None to disable logging setup
     'format': '%(message)s'
 }
 


### PR DESCRIPTION
`basicConfig` won't do anything if the root logger already has a handler.  This change will always add a basic `StreamHandler` if `level != ''`.

https://docs.python.org/3/library/logging.html#logging.basicConfig