### PR TITLE
Fix race condition when the receiver sends a message to a closed WebSocket

### DIFF
--- a/socketshark/receiver.py
+++ b/socketshark/receiver.py
@@ -102,7 +102,10 @@ class ServiceReceiver:
             subscription = channel.name.decode()[prefix_length:]
             try:
                 data = json.loads(msg.decode())
-                for session in self.confirmed_subscriptions[subscription]:
+                # The confirmed_subscriptions array may change while looping,
+                # we therefore loop over a copy.
+                sessions = list(self.confirmed_subscriptions[subscription])
+                for session in sessions:
                     await session.on_service_event(data)
                 for session in self.provisional_subscriptions[subscription]:
                     self.provisional_events[session].append(data)


### PR DESCRIPTION
If a client had high latency (ping timeout), and a service pushed out a message right after the ping timeout but before the socket fully closed, socketshark would keep running and accepting clients (even auth successfully) etc., but it wouldn't send any events from services anymore. Turns out the client would be removed from the list of subscriptions, which would cause a runtime error in the receiver.