### PR TITLE
Raise for status in aiohttp response

### DIFF
--- a/socketshark/utils.py
+++ b/socketshark/utils.py
@@ -22,6 +22,7 @@ async def http_post(shark, url, data):
                 shark.log.debug('http request', url=url, data=data)
                 async with session.post(url, json=data,
                                         timeout=opts['timeout']) as resp:
+                    resp.raise_for_status()
                     data = await resp.json()
                     shark.log.debug('http response', data=data)
                     return data


### PR DESCRIPTION
This will make non-200 error tracebacks more obvious (since the proper exception with the response code will be raised).