### PR TITLE
Logging improvements

### DIFF
--- a/socketshark/__init__.py
+++ b/socketshark/__init__.py
@@ -64,7 +64,8 @@ class SocketShark:
 
     def _init_logging(self):
         logger_name = self.config['LOG']['logger_name']
-        trace_logger_name = self.config['LOG']['trace_logger_name']
+        trace_logger_prefix = self.config['LOG']['trace_logger_prefix']
+        trace_logger_name = '{}.{}'.format(trace_logger_prefix, logger_name)
         pid = os.getpid()
         self.log = structlog.get_logger(logger_name).bind(pid=pid)
         self.trace_log = structlog.get_logger(trace_logger_name).bind(pid=pid)
@@ -255,15 +256,13 @@ def run(context, config):
         sh = logging.StreamHandler()
         sh.setFormatter(formatter)
 
-        logger = logging.getLogger(log_config['logger_name'])
+        logger = logging.getLogger()
         logger.setLevel(level)
         logger.addHandler(sh)
 
-        if log_config['trace_level']:
-            trace_level = getattr(logging, log_config['trace_level'])
-            trace_logger = logging.getLogger(log_config['trace_logger_name'])
-            trace_logger.setLevel(trace_level)
-            trace_logger.addHandler(sh)
+        trace_level = getattr(logging, log_config['trace_level'])
+        trace_logger = logging.getLogger(log_config['trace_logger_prefix'])
+        trace_logger.setLevel(trace_level)
 
     if log_config['setup_structlog']:
         setup_structlog(sys.stdout.isatty())

--- a/socketshark/backend/websockets.py
+++ b/socketshark/backend/websockets.py
@@ -32,7 +32,7 @@ class Client:
         latency = 0
         while True:
             await asyncio.sleep(ping_interval - latency)
-            self.session.log.debug('ping')
+            self.session.trace_log.debug('ping')
             start_time = time.time()
             try:
                 ping = await self.websocket.ping()
@@ -42,7 +42,7 @@ class Client:
                     self.ping_timeout_handler(ping))
             await ping
             latency = time.time() - start_time
-            self.session.log.debug('pong', latency=round(latency, 3))
+            self.session.trace_log.debug('pong', latency=round(latency, 3))
             # Return immediately if a ping timeout occurred.
             if not timeout_handler.cancel() and timeout_handler.result():
                 return

--- a/socketshark/config_defaults.py
+++ b/socketshark/config_defaults.py
@@ -9,8 +9,12 @@ LOG = {
     'level': 'INFO',  # Set to None to disable logging setup
     'format': '%(message)s',
     'logger_name': 'socketshark',
-    'trace_logger_name': 'socketshark_trace',
-    'trace_level': None,  # Set to 'DEBUG' to enable trace logger
+
+    # Trace loggers are prefixed with the value below (separated by dot).
+    'trace_logger_prefix': 'trace',
+
+    # Set to 'DEBUG' to enable trace logger, or 'INFO' or higher to disable.
+    'trace_level': 'INFO',
 }
 
 METRICS = {

--- a/socketshark/config_defaults.py
+++ b/socketshark/config_defaults.py
@@ -7,7 +7,10 @@ BACKEND = 'websockets'
 LOG = {
     'setup_structlog': True,
     'level': 'INFO',  # Set to None to disable logging setup
-    'format': '%(message)s'
+    'format': '%(message)s',
+    'logger_name': 'socketshark',
+    'trace_logger_name': 'socketshark_trace',
+    'trace_level': None,  # Set to 'DEBUG' to enable trace logger
 }
 
 METRICS = {

--- a/socketshark/events.py
+++ b/socketshark/events.py
@@ -116,6 +116,7 @@ class AuthEvent(Event):
             raise EventError(result.get('error', c.ERR_AUTH_FAILED))
         auth_info = {field: result[field] for field in auth_fields}
         self.session.auth_info = auth_info
+        self.session.log.debug('auth info', auth_info=auth_info)
         await self.send_ok()
         return True
 

--- a/socketshark/receiver.py
+++ b/socketshark/receiver.py
@@ -48,7 +48,7 @@ class ServiceReceiver:
                 # Sleep before pings
                 await asyncio.sleep(ping_interval - latency)
 
-                self.shark.log.debug('redis ping')
+                self.shark.trace_log.debug('redis ping')
 
                 start_time = time.time()
 
@@ -65,7 +65,8 @@ class ServiceReceiver:
                     break
 
                 latency = time.time() - start_time
-                self.shark.log.debug('redis pong', latency=round(latency, 3))
+                self.shark.trace_log.debug('redis pong',
+                                           latency=round(latency, 3))
 
         except asyncio.CancelledError:  # Cancelled by stop()
             if ping:
@@ -102,6 +103,7 @@ class ServiceReceiver:
             subscription = channel.name.decode()[prefix_length:]
             try:
                 data = json.loads(msg.decode())
+                self.shark.trace_log.debug('service event', data=data)
                 # The subscription arrays may change while executing
                 # on_service_event. We therefore create a snapshot before
                 # looping.

--- a/socketshark/session.py
+++ b/socketshark/session.py
@@ -20,6 +20,7 @@ class Session:
         self.config = shark.config
         self.client = client
         self.log = self.shark.log.bind(session=id(self))
+        self.trace_log = self.shark.trace_log.bind(session=id(self))
         self.log.debug('new session', **info)
         self.subscriptions = {}  # dict of Subscription objects by name
         self.active = True
@@ -66,8 +67,6 @@ class Session:
         if 'subscription' not in data or 'data' not in data:
             self.log.warn('invalid service event', data=data)
             return
-
-        self.log.debug('service event', data=data)
 
         subscription_name = data['subscription']
         subscription = self.subscriptions.get(subscription_name)

--- a/socketshark/subscription.py
+++ b/socketshark/subscription.py
@@ -121,13 +121,13 @@ class Subscription:
         Returns whether to deliver the given message.
         """
         if not self._should_deliver_message_filter_fields(data):
-            self.session.log.debug('message filtered', data=data,
-                                   reason='fields')
+            self.session.trace_log.debug('message filtered', data=data,
+                                         reason='fields')
             return False
 
         if not self._should_deliver_message_order(data):
-            self.session.log.debug('message filtered', data=data,
-                                   reason='order')
+            self.session.trace_log.debug('message filtered', data=data,
+                                         reason='order')
             return False
 
         return True

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,7 +10,7 @@ from aioredis.util import create_future
 from aioresponses import aioresponses
 import pytest
 
-from socketshark import constants as c, SocketShark
+from socketshark import config_defaults, constants as c, SocketShark
 from socketshark.session import Session
 
 LOCAL_REDIS_HOST = os.environ.get('LOCAL_REDIS_HOST')
@@ -22,6 +22,7 @@ TEST_CONFIG = {
     'WS_HOST': '127.0.0.1',
     'WS_PORT': 9001,
     'WS_PING': {'interval': 0.1, 'timeout': 0.1},
+    'LOG': config_defaults.LOG,
     'METRICS': {},
     'REDIS': {
         'host': LOCAL_REDIS_HOST,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,7 +10,8 @@ from aioredis.util import create_future
 from aioresponses import aioresponses
 import pytest
 
-from socketshark import config_defaults, constants as c, SocketShark
+from socketshark import (config_defaults, constants as c, setup_logging,
+                         SocketShark)
 from socketshark.session import Session
 
 LOCAL_REDIS_HOST = os.environ.get('LOCAL_REDIS_HOST')
@@ -78,6 +79,8 @@ TEST_CONFIG = {
         },
     },
 }
+
+setup_logging(TEST_CONFIG['LOG'])
 
 
 class aioresponses_delayed(aioresponses):  # noqa


### PR DESCRIPTION
- Split out less important messages (ping/pong, service events, message filtering) to a trace logger that can be enabled separately. But keep logging session messages in main logger.
- Log auth info, which is useful for debugging sessions.