### PR TITLE
Consolidate HTTP request log statements and scrub username/password from logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-3.5
       - test-3.6
       - test-3.7
 
@@ -27,11 +26,6 @@ defaults: &defaults
       command: PYTHONPATH=. pytest
 
 jobs:
-  test-3.5:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.5
-    - image: redis:3.2.12-alpine
   test-3.6:
     <<: *defaults
     docker:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.black]
+skip-string-normalization = true
+target-version = ['py36']
+line-length = 79
+exclude = '''
+/(
+    \.git
+  | \.venv
+  | ui
+)/
+'''

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],

--- a/socketshark/utils.py
+++ b/socketshark/utils.py
@@ -27,15 +27,24 @@ def _get_rate_limit_wait(log, resp, opts):
             if 0 <= new_wait <= max_wait:
                 wait = new_wait
             elif new_wait > max_wait:
-                log.warn('rate reset value too high',
-                         name=header_name, value=header_value)
+                log.warn(
+                    'rate reset value too high',
+                    name=header_name,
+                    value=header_value,
+                )
                 wait = max_wait
             else:
-                log.warn('invalid rate reset value',
-                         name=header_name, value=header_value)
+                log.warn(
+                    'invalid rate reset value',
+                    name=header_name,
+                    value=header_value,
+                )
         except ValueError:
-            log.warn('invalid rate reset value',
-                     name=header_name, value=header_value)
+            log.warn(
+                'invalid rate reset value',
+                name=header_name,
+                value=header_value,
+            )
     return wait
 
 
@@ -52,7 +61,10 @@ def _scrub_url(url):
             port = ''
         else:
             port = f':{url_parts.port}'
-        return f'{url_parts.scheme}://*****:*****@{url_parts.hostname}{port}{url_parts.path}?{url_parts.query}'
+        return (
+            f'{url_parts.scheme}://*****:*****@{url_parts.hostname}'
+            f'{port}{url_parts.path}?{url_parts.query}'
+        )
 
 
 async def http_post(shark, url, data):
@@ -71,8 +83,9 @@ async def http_post(shark, url, data):
             try:
                 start_time = time.time()
                 response_data = None
-                async with session.post(url, json=data,
-                                        timeout=opts['timeout']) as resp:
+                async with session.post(
+                    url, json=data, timeout=opts['timeout']
+                ) as resp:
                     if resp.status == 429:  # Too many requests.
                         wait = _get_rate_limit_wait(log, resp, opts)
                         continue
@@ -86,5 +99,10 @@ async def http_post(shark, url, data):
             except asyncio.TimeoutError:
                 log.exception('timeout in http_post')
             finally:
-                log.debug('http request', request=data, response=response_data, duration=time.time() - start_time)
+                log.debug(
+                    'http request',
+                    request=data,
+                    response=response_data,
+                    duration=time.time() - start_time,
+                )
         return {'status': 'error', 'error': c.ERR_SERVICE_UNAVAILABLE}

--- a/socketshark/utils.py
+++ b/socketshark/utils.py
@@ -1,5 +1,7 @@
 import asyncio
 import ssl
+import time
+from urllib.parse import urlsplit
 
 import aiohttp
 
@@ -37,8 +39,24 @@ def _get_rate_limit_wait(log, resp, opts):
     return wait
 
 
+def _scrub_url(url):
+    """Scrub URL username and password."""
+    url_parts = urlsplit(url)
+    if url_parts.password is None:
+        return url
+    else:
+        # url_parts tuple doesn't include password in _fields
+        # so can't easily use _replace to get rid of password
+        # and then call urlunsplit to reconstruct url.
+        if url_parts.port is None:
+            port = ''
+        else:
+            port = f':{url_parts.port}'
+        return f'{url_parts.scheme}://*****:*****@{url_parts.hostname}{port}{url_parts.path}?{url_parts.query}'
+
+
 async def http_post(shark, url, data):
-    log = shark.log.bind(url=url)
+    log = shark.log.bind(url=_scrub_url(url))
     opts = shark.config['HTTP']
     if opts.get('ssl_cafile'):
         ssl_context = ssl.create_default_context(cafile=opts['ssl_cafile'])
@@ -51,7 +69,8 @@ async def http_post(shark, url, data):
             if n > 0:
                 await asyncio.sleep(wait)
             try:
-                log.debug('http request', data=data)
+                start_time = time.time()
+                response_data = None
                 async with session.post(url, json=data,
                                         timeout=opts['timeout']) as resp:
                     if resp.status == 429:  # Too many requests.
@@ -60,11 +79,12 @@ async def http_post(shark, url, data):
                     else:
                         wait = opts['wait']
                     resp.raise_for_status()
-                    data = await resp.json()
-                    log.debug('http response', data=data)
-                    return data
+                    response_data = await resp.json()
+                    return response_data
             except aiohttp.ClientError:
                 log.exception('unhandled exception in http_post')
             except asyncio.TimeoutError:
                 log.exception('timeout in http_post')
+            finally:
+                log.debug('http request', request=data, response=response_data, duration=time.time() - start_time)
         return {'status': 'error', 'error': c.ERR_SERVICE_UNAVAILABLE}

--- a/socketshark/utils.py
+++ b/socketshark/utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import ssl
 import time
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 import aiohttp
 
@@ -57,14 +57,10 @@ def _scrub_url(url):
         # url_parts tuple doesn't include password in _fields
         # so can't easily use _replace to get rid of password
         # and then call urlunsplit to reconstruct url.
-        if url_parts.port is None:
-            port = ''
-        else:
-            port = f':{url_parts.port}'
-        return (
-            f'{url_parts.scheme}://*****:*****@{url_parts.hostname}'
-            f'{port}{url_parts.path}?{url_parts.query}'
-        )
+        _, _, hostinfo = url_parts.netloc.rpartition('@')
+        scrubbed_netloc = f'*****:*****@{hostinfo}'
+        scrubbed_url_parts = url_parts._replace(netloc=scrubbed_netloc)
+        return urlunsplit(scrubbed_url_parts)
 
 
 async def http_post(shark, url, data):


### PR DESCRIPTION
* This consolidates the two http request log statements which will reduce the number of log records and slightly reduce storage used by saving overhead for the extra log statement. It's also probably a more useful log statement since request, response, and timing are all in the same record which makes it easily to parse on a busy server.
* Also scrubs the URL so username/passwords don't get logged.
* Removed py3.5 support since it is EOL and wanted to use f strings. Tried adding 3.8 but got linting errors so will tackle that at another time.

Commits can be reviewed separately.