### PR TITLE
Add ping/pong event

### DIFF
--- a/socketshark/events.py
+++ b/socketshark/events.py
@@ -21,6 +21,7 @@ class Event:
             'message': MessageEvent,
             'subscribe': SubscribeEvent,
             'unsubscribe': UnsubscribeEvent,
+            'ping': PingEvent,
         }.get(event)
 
         if cls:
@@ -165,4 +166,22 @@ class UnsubscribeEvent(SubscriptionEvent):
     async def process(self):
         await super().process()
         await self.subscription.unsubscribe(self)
+        return True
+
+
+class PingEvent(Event):
+    async def send_pong(self, data=None):
+        msg = {
+            'event': 'pong',
+            'data': data
+        }
+        await self.session.send(msg)
+
+    async def process(self):
+        raw_data = self.data.get('data')
+        if isinstance(raw_data, str):
+            data = raw_data[:128]
+        else:
+            data = None
+        await self.send_pong(data)
         return True

--- a/socketshark/events.py
+++ b/socketshark/events.py
@@ -179,9 +179,14 @@ class PingEvent(Event):
 
     async def process(self):
         raw_data = self.data.get('data')
+
+        # If the "ping" event included some "data", send the same data back
+        # so that pings and their pongs can be tied together. However, only
+        # accept string data and only up to 128 characters.
         if isinstance(raw_data, str):
             data = raw_data[:128]
         else:
             data = None
+
         await self.send_pong(data)
         return True

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1610,6 +1610,30 @@ class TestSession:
 
         await shark.shutdown()
 
+    @pytest.mark.asyncio
+    async def test_ping_pong(self):
+        shark = SocketShark(TEST_CONFIG)
+        client = MockClient(shark)
+        session = client.session
+
+        await session.on_client_event({'event': 'ping'})
+        assert client.log.pop() == {
+            'event': 'pong',
+            'data': None,
+        }
+
+        await session.on_client_event({'event': 'ping', 'data': 123})
+        assert client.log.pop() == {
+            'event': 'pong',
+            'data': None,
+        }
+
+        await session.on_client_event({'event': 'ping', 'data': 'hello'})
+        assert client.log.pop() == {
+            'event': 'pong',
+            'data': 'hello',
+        }
+
 
 class TestThrottle:
     """

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1612,27 +1612,29 @@ class TestSession:
 
     @pytest.mark.asyncio
     async def test_ping_pong(self):
+        """
+        Test receiving a "ping" from the client and responding with a "pong".
+        """
         shark = SocketShark(TEST_CONFIG)
         client = MockClient(shark)
         session = client.session
 
-        await session.on_client_event({'event': 'ping'})
-        assert client.log.pop() == {
-            'event': 'pong',
-            'data': None,
-        }
+        message_from_client = {'event': 'ping'}
+        await session.on_client_event(message_from_client)
+        message_from_server = client.log.pop()
+        assert message_from_server == {'event': 'pong', 'data': None}
 
-        await session.on_client_event({'event': 'ping', 'data': 123})
-        assert client.log.pop() == {
-            'event': 'pong',
-            'data': None,
-        }
+        # Only a string payload is sent back to the client. Other data types
+        # (e.g. int) should be ignored.
+        message_from_client = {'event': 'ping', 'data': 123}
+        await session.on_client_event(message_from_client)
+        message_from_server = client.log.pop()
+        assert message_from_server == {'event': 'pong', 'data': None}
 
-        await session.on_client_event({'event': 'ping', 'data': 'hello'})
-        assert client.log.pop() == {
-            'event': 'pong',
-            'data': 'hello',
-        }
+        message_from_client = {'event': 'ping', 'data': 'hello'}
+        await session.on_client_event(message_from_client)
+        message_from_server = client.log.pop()
+        assert message_from_server == {'event': 'pong', 'data': 'hello'}
 
 
 class TestThrottle:


### PR DESCRIPTION
This PR adds support for a `ping` event coming from a WebSocket Client. When SocketShark receives such an event, it immediately responds with a `pong`, without contacting any other services. Clients may choose to send pings and monitor for pongs to e.g. detect failed WebSocket connections [0], display latency metrics, etc. Furthermore, the `ping` message may contain some data, which the `pong` message should repeat back. These messages are implemented as regular data frames [1].

---
[0] This was the main motivation for implementing this feature. SocketShark already implements [Server-side pings](https://github.com/closeio/socketshark/blob/fb6ada0413754edf5228d8d50a39e378e8b08908/socketshark/backend/websockets.py#L38), but Client-side pings are also necessary for a comprehensive detection of connection issues. For example, imagine a scenario in which your Internet connectivity is broken (e.g. you unplug the Ethernet cable from your router). In this case, the Server-side `Ping` will not receive a `Pong` back and thus it'll [close the connection](https://github.com/closeio/socketshark/blob/fb6ada0413754edf5228d8d50a39e378e8b08908/socketshark/backend/websockets.py#L24). However, the TCP FIN packet will never reach the Client because, well, connectivity issues. The Client will thus not realize its WebSocket connection is broken until it attempts to send another message.
[1] There was a discussion a while back about allowing Clients to send actual `Ping`/`Pong` [control frames](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5) on demand, but [W3 has decided not to expose this as a browser API](https://www.w3.org/Bugs/Public/show_bug.cgi?id=13104). This is why we need to implement this mechanism using regular [data frames](https://datatracker.ietf.org/doc/html/rfc6455#section-5.6).