### PR TITLE
Drop testing on 3.6, add testing on 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ defaults: &defaults
   - run:
       name: Install dependencies
       command: |
-        sudo pip install -r requirements_tests.txt
+        pip install -r requirements_tests.txt
   - run:
       name: Test
       command: PYTHONPATH=. pytest
@@ -35,7 +35,7 @@ jobs:
   static-code-analysis:
     <<: *defaults
     docker:
-    - image: circleci/python:3.8
+    - image: cimg/python:3.8
       auth:
         username: $DOCKER_USER
         password: $DOCKER_PASS
@@ -56,7 +56,7 @@ jobs:
   test-3.7:
     <<: *defaults
     docker:
-    - image: circleci/python:3.7
+    - image: cimg/python:3.7
       auth:
         username: $DOCKER_USER
         password: $DOCKER_PASS
@@ -67,7 +67,7 @@ jobs:
   test-3.8:
     <<: *defaults
     docker:
-    - image: circleci/python:3.8
+    - image: cimg/python:3.8
       auth:
         username: $DOCKER_USER
         password: $DOCKER_PASS
@@ -78,7 +78,7 @@ jobs:
   test-3.9:
     <<: *defaults
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,6 @@ workflows:
       - test-3.9:
           context:
             - docker-hub-creds-ro
-      - test-3.10:
-          context:
-            - docker-hub-creds-ro
 
 defaults: &defaults
   working_directory: ~/code
@@ -82,17 +79,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/python:3.9
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-      - image: redis:3.2.12-alpine
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-  test-3.10:
-    <<: *defaults
-    docker:
-      - image: circleci/python:3.10
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,16 @@ workflows:
       - static-code-analysis:
           context:
             - docker-hub-creds-ro
-      - test-3.6:
-          context:
-            - docker-hub-creds-ro
       - test-3.7:
           context:
             - docker-hub-creds-ro
       - test-3.8:
+          context:
+            - docker-hub-creds-ro
+      - test-3.9:
+          context:
+            - docker-hub-creds-ro
+      - test-3.10:
           context:
             - docker-hub-creds-ro
 
@@ -53,17 +56,6 @@ jobs:
           command: |
             lintlizard
 
-  test-3.6:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.6
-      auth:
-        username: $DOCKER_USER
-        password: $DOCKER_PASS
-    - image: redis:3.2.12-alpine
-      auth:
-        username: $DOCKER_USER
-        password: $DOCKER_PASS
   test-3.7:
     <<: *defaults
     docker:
@@ -86,3 +78,25 @@ jobs:
       auth:
         username: $DOCKER_USER
         password: $DOCKER_PASS
+  test-3.9:
+    <<: *defaults
+    docker:
+      - image: circleci/python:3.9
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+      - image: redis:3.2.12-alpine
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+  test-3.10:
+    <<: *defaults
+    docker:
+      - image: circleci/python:3.10
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+      - image: redis:3.2.12-alpine
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,1 +1,2 @@
 lintlizard==0.15.0
+click<8.1  # 8.1+ breaks black


### PR DESCRIPTION
This PR does a minor refresh of CI:
* drop testing 3.6
* add testing for 3.9 (3.10 requires some dependency upgrades still)
* pin lower `click` version (to get black working again)
* swap out `circleci/python` for `cimg/python` (`circleci/` images are deprecated)