### PR TITLE
Bump number of PRs dependabot can open

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   # Enable version updates for python
   - package-ecosystem: "pip"
     directory: "/"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 20
     schedule:
       interval: "daily"
     pull-request-branch-name:


### PR DESCRIPTION
There are more dependencies we want to update, so this will help to ship those while some others stay open because they need more manual intervention.