### PR TITLE
Give the ability to optionally install prometheus

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ setup(
     tests_require=tests_require,
     platforms='any',
     install_requires=install_requires,
+    extras_require={
+        'prometheus': 'prometheus-async',
+    },
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
`prometheus-async` is an optional `socketshark` dependency. It should be installed optionally.
```
socketshark[prometheus]
```

If you agree with this PR, I'll update the docs.

Thanks :).