### PR TITLE
Remove structlog dev optional dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = [
     'aiohttp',
     'aioredis',
     'click',
-    'structlog[dev]',
+    'structlog',
     'websockets',
 ]
 


### PR DESCRIPTION
Based on this [issue](https://github.com/closeio/socketshark/issues/160), the optional dependency on `structlog dev` has been removed from the setup.py file.

https://github.com/closeio/socketshark/issues/160

Thank you.