### PR TITLE
Add subscription heartbeats

### DIFF
--- a/example_config.py
+++ b/example_config.py
@@ -60,5 +60,9 @@ SERVICES = {
         "on_unsubscribe": 'http://my-service/on_unsubscribe/',
         # URL which is called when a message is passed to this service.
         "on_message": 'http://my-service/on_message/',
+        # If set, the service will send a heartbeat message to the URL defined
+        # in 'on_heartbeat' every 'heartbeat_period' seconds.
+        "heartbeat_period": 30,
+        "on_heartbeat": 'http://my-service/on_heartbeat/',
     },
 }

--- a/socketshark/subscription.py
+++ b/socketshark/subscription.py
@@ -83,6 +83,7 @@ class Subscription:
         self.throttle_state = {}
 
         self._periodic_authorizer_task = None
+        self._periodic_heartbeat_task = None
 
     def validate(self):
         if not self.service or not self.topic:
@@ -450,6 +451,9 @@ class Subscription:
 
         if self._periodic_authorizer_task:
             self._periodic_authorizer_task.cancel()
+
+        if self._periodic_heartbeat_task:
+            self._periodic_heartbeat_task.cancel()
 
     async def unsubscribe(self, event):
         """


### PR DESCRIPTION
While we do take many precautions we are still occasionally leaking connections - an example redeploy of Socketshark showed 10% of DMS subscriptions are stale (e.g. do not have a corresponding subscription in Socketshark), and that's on top of us deleting subscriptions after 7 days.

This PR introduces an optional heartbeat mechanism so that the service can keep track of heartbeats and do its own cleanup if it wants to.