### PR TITLE
Bump idna 3.3->3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ chardet==3.0.3
 click==8.0.4
 frozenlist==1.3.0
 hiredis==0.2.0
-idna==3.3
+idna==3.7
 multidict==5.2.0
 packaging==21.3
 pyparsing==2.2.0


### PR DESCRIPTION
Dependency of aiohttp->yarl. Changes reviewed and tested in https://github.com/closeio/closeio-socketshark/pull/179