### PR TITLE
Run tests on Python 3.11 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ workflows:
       - test-3.9:
           context:
             - docker-hub-creds-ro
+      - test-3.11:
+          context:
+            - docker-hub-creds-ro
 
 defaults: &defaults
   working_directory: ~/code
@@ -65,6 +68,17 @@ jobs:
     <<: *defaults
     docker:
       - image: cimg/python:3.9
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+      - image: redis:3.2.12-alpine
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+  test-3.11:
+    <<: *defaults
+    docker:
+      - image: cimg/python:3.11
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ defaults: &defaults
     - run:
         name: Install dependencies
         command: |
-          pip install -r requirements_tests.txt
+          pip install --no-deps -r requirements_tests.txt
     - run:
         name: Test
         command: PYTHONPATH=. pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,14 +2,11 @@ aiohttp==3.9.5
 aioredis==1.3.1
 aiosignal==1.2.0
 async-timeout==4.0.2
-chardet==3.0.3
 click==8.0.4
 frozenlist==1.3.0
-hiredis==0.2.0
 idna==3.7
 multidict==5.2.0
 packaging==21.3
-pyparsing==2.2.0
 structlog==20.1.0
 websockets==12.0
 yarl==1.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,13 @@ aiohttp==3.9.5
 aioredis==1.3.1
 aiosignal==1.2.0
 async-timeout==4.0.2
+attrs==24.2.0
 click==8.0.4
-frozenlist==1.3.0
+frozenlist==1.4.0
+hiredis==2.1.0
 idna==3.7
 multidict==5.2.0
-packaging==21.3
+six==1.16.0
 structlog==20.1.0
 websockets==12.0
-yarl==1.7.2
+yarl==1.9.3

--- a/requirements_prometheus.txt
+++ b/requirements_prometheus.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 prometheus-async==17.3.0
 prometheus-client==0.0.19
-
+wrapt==1.16.0

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,6 +1,9 @@
 -r requirements_prometheus.txt
 aioresponses==0.7.6
 asynctest==0.13.0
+exceptiongroup==1.2.2
+iniconfig==2.0.0
+pluggy==1.5.0
 pytest==8.0.2
 pytest-asyncio==0.21.1
-
+tomli==2.0.1


### PR DESCRIPTION
The most recent `hiredis` release does not support Python 3.12 yet.

This PR updates the requirements that are used to run tests for socketshark.
The requirements are all pinned, and installed without dependencies for deterministic and consistent runs.