### PR TITLE
Upgrade aiohttp to 3.10.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-aiohttp==3.9.5
+aiohappyeyeballs==2.4.3
+aiohttp==3.10.9
 aioredis==1.3.1
 aiosignal==1.2.0
 async-timeout==4.0.2
@@ -8,7 +9,8 @@ frozenlist==1.4.0
 hiredis==2.1.0
 idna==3.7
 multidict==5.2.0
+propcache==0.2.0
 six==1.16.0
 structlog==20.1.0
 websockets==12.0
-yarl==1.9.3
+yarl==1.14.0


### PR DESCRIPTION
One change from the Changelog that is relevant is the following (from version 3.10.3):

Fixed `aiohttp.TCPConnector` doing blocking I/O in the event loop to create the SSLContext.

Supersedes #219 and #218.