### PR TITLE
Run tests on Python 3.12 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ workflows:
       - test-3.11:
           context:
             - docker-hub-creds-ro
+      - test-3.12:
+          context:
+            - docker-hub-creds-ro
 
 defaults: &defaults
   working_directory: ~/code
@@ -79,6 +82,17 @@ jobs:
     <<: *defaults
     docker:
       - image: cimg/python:3.11
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+      - image: redis:3.2.12-alpine
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+  test-3.12:
+    <<: *defaults
+    docker:
+      - image: cimg/python:3.12
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ async-timeout==4.0.2
 attrs==24.2.0
 click==8.0.4
 frozenlist==1.4.0
-hiredis==2.1.0
+hiredis==2.1.1
 idna==3.7
 multidict==5.2.0
 propcache==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ hiredis==2.1.1
 idna==3.7
 multidict==5.2.0
 propcache==0.2.0
-six==1.16.0
+six==1.17.0
 structlog==20.1.0
 websockets==12.0
 yarl==1.14.0


### PR DESCRIPTION
Upgrading the closeio-socketshark base image which will start using Python 3.12 https://github.com/closeio/closeio-socketshark/pull/201 