### PR TITLE
Pass through `published_at`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         redis-version: ["3.2.12"]
     services:
       redis:

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ line_length=79
 float_to_top=True
 
 [mypy]
-python_version = 3.6
+python_version = 3.10
 ignore_missing_imports = True
 no_implicit_optional = True
 strict_equality = True

--- a/socketshark/session.py
+++ b/socketshark/session.py
@@ -1,3 +1,4 @@
+import datetime
 from . import constants as c
 from .events import Event, InvalidEvent, UnknownEvent
 
@@ -81,14 +82,28 @@ class Session:
         if not subscription.should_deliver_message(data):
             return
 
-        await self.send_message(subscription, data['data'])
+        published_at = data.get('published_at')
+        if published_at is not None:
+            try:
+                published_at = datetime.datetime.fromisoformat(published_at)
+            except ValueError:
+                self.log.warn(
+                    'invalid published_at format', published_at=published_at
+                )
+                published_at = None
 
-    async def send_message(self, subscription, data):
+        await self.send_message(subscription, data['data'], published_at)
+
+    async def send_message(
+        self, subscription, data, published_at: datetime.datetime | None = None
+    ):
         msg = {
             'event': 'message',
             'subscription': subscription.name,
             'data': data,
         }
+        if published_at is not None:
+            msg['published_at'] = published_at.isoformat()
         msg.update(subscription.extra_data)
         await self.send(msg)
 

--- a/socketshark/session.py
+++ b/socketshark/session.py
@@ -1,4 +1,5 @@
 import datetime
+
 from . import constants as c
 from .events import Event, InvalidEvent, UnknownEvent
 


### PR DESCRIPTION
What
====

- Pass through `published_at` if it exists on the payload
- Bump minimal Python version to 3.10 since I used 3.10+ union syntax `A | B` and also 3.9 is EOL already