### PR TITLE
Add `received_at`, `sent_at`, `queue_size`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,8 @@ exclude = '''
   | ui
 )/
 '''
+
+[project]
+name = "socketshark"
+version = "0.5.0"
+requires-python = ">=3.10"

--- a/socketshark/__init__.py
+++ b/socketshark/__init__.py
@@ -119,7 +119,7 @@ class SocketShark:
         If one goes down, the service will shut down to communicate to
         Websocket clients to attempt to reconnect to another host.
         """
-        tasks = [c.redis.wait_closed() for c in self.redis_connections]
+        tasks = [asyncio.ensure_future(c.redis.wait_closed()) for c in self.redis_connections]
         await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
 
         self.log.error('redis unexpectedly closed')

--- a/socketshark/__init__.py
+++ b/socketshark/__init__.py
@@ -119,7 +119,10 @@ class SocketShark:
         If one goes down, the service will shut down to communicate to
         Websocket clients to attempt to reconnect to another host.
         """
-        tasks = [asyncio.ensure_future(c.redis.wait_closed()) for c in self.redis_connections]
+        tasks = [
+            asyncio.ensure_future(c.redis.wait_closed())
+            for c in self.redis_connections
+        ]
         await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
 
         self.log.error('redis unexpectedly closed')

--- a/socketshark/receiver.py
+++ b/socketshark/receiver.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import json
 import time
 from collections import defaultdict
@@ -107,6 +108,7 @@ class ServiceReceiver:
 
         while True:
             data = await connection.redis_receiver.get()
+            received_at = datetime.datetime.now(datetime.timezone.utc)
             channel, msg = data
             if channel == connection.stop_channel:
                 break
@@ -124,7 +126,9 @@ class ServiceReceiver:
                     self.provisional_subscriptions[subscription]
                 )
                 for session in confirmed_sessions:
-                    await session.on_service_event(data)
+                    await session.on_service_event(
+                        data, received_at=received_at
+                    )
                 for session in provisional_sesssions:
                     self.provisional_events[session].append(data)
             except json.decoder.JSONDecodeError:

--- a/socketshark/receiver.py
+++ b/socketshark/receiver.py
@@ -103,7 +103,8 @@ class ServiceReceiver:
 
     async def _reader_for_connection(self, connection, once=False):
         prefix_length = len(connection.channel_prefix)
-        if once and not connection.redis_receiver._queue.qsize():
+        queue_size = connection.redis_receiver._queue.qsize()
+        if once and not queue_size:
             return False
 
         while True:
@@ -127,7 +128,7 @@ class ServiceReceiver:
                 )
                 for session in confirmed_sessions:
                     await session.on_service_event(
-                        data, received_at=received_at
+                        data, received_at=received_at, queue_size=queue_size
                     )
                 for session in provisional_sesssions:
                     self.provisional_events[session].append(data)

--- a/socketshark/session.py
+++ b/socketshark/session.py
@@ -66,6 +66,7 @@ class Session:
         data,
         *,
         received_at: datetime.datetime | None = None,
+        queue_size: int | None = None,
     ):
         """
         Callback called by the ServiceReceiver.
@@ -103,6 +104,7 @@ class Session:
             data['data'],
             published_at=published_at,
             received_at=received_at,
+            queue_size=queue_size,
         )
 
     async def send_message(
@@ -112,6 +114,7 @@ class Session:
         *,
         published_at: datetime.datetime | None = None,
         received_at: datetime.datetime | None = None,
+        queue_size: int | None = None,
     ):
         msg = {
             'event': 'message',
@@ -122,6 +125,8 @@ class Session:
             msg['published_at'] = published_at.isoformat()
         if received_at is not None:
             msg['received_at'] = received_at.isoformat()
+        if queue_size is not None:
+            msg['queue_size'] = queue_size
         msg.update(subscription.extra_data)
         msg['sent_at'] = datetime.datetime.now(
             datetime.timezone.utc

--- a/socketshark/session.py
+++ b/socketshark/session.py
@@ -61,7 +61,12 @@ class Session:
             await event.send_error(c.ERR_UNHANDLED_EXCEPTION)
             await self.close()
 
-    async def on_service_event(self, data):
+    async def on_service_event(
+        self,
+        data,
+        *,
+        received_at: datetime.datetime | None = None,
+    ):
         """
         Callback called by the ServiceReceiver.
 
@@ -93,10 +98,20 @@ class Session:
                 )
                 published_at = None
 
-        await self.send_message(subscription, data['data'], published_at)
+        await self.send_message(
+            subscription,
+            data['data'],
+            published_at=published_at,
+            received_at=received_at,
+        )
 
     async def send_message(
-        self, subscription, data, published_at: datetime.datetime | None = None
+        self,
+        subscription,
+        data,
+        *,
+        published_at: datetime.datetime | None = None,
+        received_at: datetime.datetime | None = None,
     ):
         msg = {
             'event': 'message',
@@ -105,7 +120,13 @@ class Session:
         }
         if published_at is not None:
             msg['published_at'] = published_at.isoformat()
+        if received_at is not None:
+            msg['received_at'] = received_at.isoformat()
         msg.update(subscription.extra_data)
+        msg['sent_at'] = datetime.datetime.now(
+            datetime.timezone.utc
+        ).isoformat()
+
         await self.send(msg)
 
     async def send_unsubscribe(self, subscription, data=None, error=None):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,7 +3,7 @@ import json
 import os
 import random
 import time
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import aiohttp
 import aioredis
@@ -594,11 +594,15 @@ class TestSession:
                 'event': 'message',
                 'subscription': 'simple.topic',
                 'data': {'baz': 'foo'},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': 'simple.topic',
                 'data': {'arrives': True},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
         ]
 
@@ -709,11 +713,15 @@ class TestSession:
                 'event': 'message',
                 'subscription': 'simple_auth.topic',
                 'data': {'foo': 'bar'},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': 'simple_auth.topic',
                 'data': {'arrives': True},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
         ]
 
@@ -1339,6 +1347,8 @@ class TestSession:
             'subscription': 'complex.topic',
             'data': {'foo': 'bar'},
             'extra': 'hello',
+            'received_at': ANY,
+            'sent_at': ANY,
         }
 
         # Test unsubscribe callbacks
@@ -1650,26 +1660,36 @@ class TestSession:
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'msg': 4},  # order 3
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'msg': 5},  # order 5
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'msg': 8},  # order 6
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'other': 1},  # other order 1
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'other': 2},  # other order 3
+                'received_at': ANY,
+                'sent_at': ANY,
             },
         ]
 
@@ -1736,11 +1756,15 @@ class TestSession:
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'foo': 'invalid'},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'foo': 'bar'},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
         ]
 
@@ -1806,6 +1830,8 @@ class TestSession:
                 'subscription': subscription,
                 'extra': 'bar',
                 'data': {'test': 'bar'},
+                'received_at': ANY,
+                'sent_at': ANY,
             }
         ]
 
@@ -2064,26 +2090,36 @@ class TestThrottle:
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'foo': 'one'},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'bar': 'one'},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'invalid': 'one'},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'unthrottled': 'one'},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'unthrottled': 'two'},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
         ]
         client.log = []
@@ -2096,6 +2132,7 @@ class TestThrottle:
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'foo': 'three'},
+                'sent_at': ANY,
             }
         ]
         client.log = []
@@ -2123,6 +2160,8 @@ class TestThrottle:
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'foo': 'four'},
+                'received_at': ANY,
+                'sent_at': ANY,
             }
         ]
 
@@ -2185,6 +2224,8 @@ class TestThrottle:
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'foo': 'one'},
+                'received_at': ANY,
+                'sent_at': ANY,
             }
         ]
 
@@ -2259,6 +2300,8 @@ class TestThrottle:
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'foo': 'one'},
+                'received_at': ANY,
+                'sent_at': ANY,
             }
         ]
         client.log = []
@@ -2305,6 +2348,7 @@ class TestThrottle:
             'event': 'message',
             'subscription': subscription,
             'data': {'foo': 'two'},
+            'sent_at': ANY,
         }
 
         if throttle - wait > 0:
@@ -2318,6 +2362,7 @@ class TestThrottle:
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'foo': 'three'},
+                'sent_at': ANY,
             }
         ]
 
@@ -2657,6 +2702,8 @@ class TestWebsocket:
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'baz': 'new'},
+                'received_at': ANY,
+                'sent_at': ANY,
             }
 
             redis.close()
@@ -2779,11 +2826,15 @@ class TestRedisConnection:
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'foo': 'one'},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
             {
                 'event': 'message',
                 'subscription': subscription,
                 'data': {'bar': 'one'},
+                'received_at': ANY,
+                'sent_at': ANY,
             },
         ]
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -595,6 +595,7 @@ class TestSession:
                 'subscription': 'simple.topic',
                 'data': {'baz': 'foo'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -602,6 +603,7 @@ class TestSession:
                 'subscription': 'simple.topic',
                 'data': {'arrives': True},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
         ]
@@ -714,6 +716,7 @@ class TestSession:
                 'subscription': 'simple_auth.topic',
                 'data': {'foo': 'bar'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -721,6 +724,7 @@ class TestSession:
                 'subscription': 'simple_auth.topic',
                 'data': {'arrives': True},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
         ]
@@ -1348,6 +1352,7 @@ class TestSession:
             'data': {'foo': 'bar'},
             'extra': 'hello',
             'received_at': ANY,
+            'queue_size': ANY,
             'sent_at': ANY,
         }
 
@@ -1661,6 +1666,7 @@ class TestSession:
                 'subscription': subscription,
                 'data': {'msg': 4},  # order 3
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -1668,6 +1674,7 @@ class TestSession:
                 'subscription': subscription,
                 'data': {'msg': 5},  # order 5
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -1675,6 +1682,7 @@ class TestSession:
                 'subscription': subscription,
                 'data': {'msg': 8},  # order 6
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -1682,6 +1690,7 @@ class TestSession:
                 'subscription': subscription,
                 'data': {'other': 1},  # other order 1
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -1689,6 +1698,7 @@ class TestSession:
                 'subscription': subscription,
                 'data': {'other': 2},  # other order 3
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
         ]
@@ -1757,6 +1767,7 @@ class TestSession:
                 'subscription': subscription,
                 'data': {'foo': 'invalid'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -1764,6 +1775,7 @@ class TestSession:
                 'subscription': subscription,
                 'data': {'foo': 'bar'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
         ]
@@ -1831,6 +1843,7 @@ class TestSession:
                 'extra': 'bar',
                 'data': {'test': 'bar'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             }
         ]
@@ -2091,6 +2104,7 @@ class TestThrottle:
                 'subscription': subscription,
                 'data': {'foo': 'one'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -2098,6 +2112,7 @@ class TestThrottle:
                 'subscription': subscription,
                 'data': {'bar': 'one'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -2105,6 +2120,7 @@ class TestThrottle:
                 'subscription': subscription,
                 'data': {'invalid': 'one'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -2112,6 +2128,7 @@ class TestThrottle:
                 'subscription': subscription,
                 'data': {'unthrottled': 'one'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -2119,6 +2136,7 @@ class TestThrottle:
                 'subscription': subscription,
                 'data': {'unthrottled': 'two'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
         ]
@@ -2161,6 +2179,7 @@ class TestThrottle:
                 'subscription': subscription,
                 'data': {'foo': 'four'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             }
         ]
@@ -2225,6 +2244,7 @@ class TestThrottle:
                 'subscription': subscription,
                 'data': {'foo': 'one'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             }
         ]
@@ -2301,6 +2321,7 @@ class TestThrottle:
                 'subscription': subscription,
                 'data': {'foo': 'one'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             }
         ]
@@ -2703,6 +2724,7 @@ class TestWebsocket:
                 'subscription': subscription,
                 'data': {'baz': 'new'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             }
 
@@ -2827,6 +2849,7 @@ class TestRedisConnection:
                 'subscription': subscription,
                 'data': {'foo': 'one'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
             {
@@ -2834,6 +2857,7 @@ class TestRedisConnection:
                 'subscription': subscription,
                 'data': {'bar': 'one'},
                 'received_at': ANY,
+                'queue_size': ANY,
                 'sent_at': ANY,
             },
         ]


### PR DESCRIPTION
What
====

Add `received_at`, `sent_at`, `queue_size` to websocket messages


- `received_at` when it was handed over from Redis to socketshark
- `sent_at` when it was handed over from socketshark to websocket
- `queue_size` how many messages were there on the subscription before receiving a message


Other fixes I did because I found out hard to work on this project:

- add bare minimum in `pyproject.toml` in this project so I can work with `uv run`.
- Fix a warning that is shown in tests on Python 3.10 and newer.

