### PR TITLE
Remove project from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,3 @@ exclude = '''
   | ui
 )/
 '''
-
-[project]
-name = "socketshark"
-version = "0.5.0"
-requires-python = ">=3.10"


### PR DESCRIPTION
Remove pyproject.toml project section because it confuses setuptools. We should convert fully to uv instead.