### PR TITLE
Add Claude local stuff to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dist/
 __pycache__
 venv
 .venv
+CLAUDE.local.md
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
Why: Different engineers have different workflows and they often include personalized instructions in local Claude files. Today, these files are tracked by git and distract the engineers from actual changes.