### PR TITLE
Make mypy stricter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -105,4 +105,44 @@ pretty = True
 files = socketshark
 mypy_path = $MYPY_CONFIG_FILE_DIR/stubs
 namespace_packages = True
-check_untyped_defs = True
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+
+# The following modules have not yet been fully type-annotated. Allow untyped
+# defs in them until they get typed, then remove the corresponding override.
+[mypy-socketshark]
+allow_untyped_defs = True
+
+[mypy-socketshark.backend.websockets]
+allow_untyped_defs = True
+
+[mypy-socketshark.events]
+allow_untyped_defs = True
+
+[mypy-socketshark.exceptions]
+allow_untyped_defs = True
+
+[mypy-socketshark.metrics]
+allow_untyped_defs = True
+
+[mypy-socketshark.metrics.prometheus]
+allow_untyped_defs = True
+
+[mypy-socketshark.receiver]
+allow_untyped_defs = True
+
+[mypy-socketshark.redis_connection]
+allow_untyped_defs = True
+allow_incomplete_defs = True
+
+[mypy-socketshark.session]
+allow_untyped_defs = True
+allow_incomplete_defs = True
+
+[mypy-socketshark.subscription]
+allow_untyped_defs = True
+
+[mypy-socketshark.utils]
+allow_untyped_defs = True


### PR DESCRIPTION
Part of https://github.com/closeio/socketshark/issues/326.

Now, by default, we disallow any untyped and incomplete definitions.  This will make it easier to type-annotate code module by module, incrementally tightening the static analysis.
