### PR TITLE
Fix `queue_size` calculation

### DIFF
--- a/socketshark/receiver.py
+++ b/socketshark/receiver.py
@@ -103,11 +103,11 @@ class ServiceReceiver:
 
     async def _reader_for_connection(self, connection, once=False):
         prefix_length = len(connection.channel_prefix)
-        queue_size = connection.redis_receiver._queue.qsize()
-        if once and not queue_size:
+        if once and not connection.redis_receiver._queue.qsize():
             return False
 
         while True:
+            queue_size = connection.redis_receiver._queue.qsize()
             data = await connection.redis_receiver.get()
             received_at = datetime.datetime.now(datetime.timezone.utc)
             channel, msg = data


### PR DESCRIPTION
@marcotisi found it in https://github.com/closeio/dialer/issues/1505#issuecomment-4324302541.

Our previous implementation done in https://github.com/closeio/socketshark/pull/322 had a bug. We were only calculating the queue size once per connection, but the same connection can have a very deep queue at one point and no queue at another point. We have to check the queue size once *per loop iteration*, basically every time we pop a message off the queue.
