### PR TITLE
Assign ownership to Close's Team Communications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The whole Dialer repository is owned by one team.
+* @closeio/communications-backend

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,5 @@ updates:
     pull-request-branch-name:
       # so it's compatible with docker tags
       separator: "-"
-
+    assignees:
+      - closeio/communications-backend


### PR DESCRIPTION
This is the team responsible for maintaining SocketShark within Close.

Thanks to these rules, the team will be notified every time there's a PR, no matter if it's created by Dependabot or a human author.
