### PR TITLE
Process service events asynchronously

### DIFF
--- a/socketshark/receiver.py
+++ b/socketshark/receiver.py
@@ -126,9 +126,9 @@ class ServiceReceiver:
 
         while True:
             queue_size = connection.redis_receiver._queue.qsize()
-            data = await connection.redis_receiver.get()
+            redis_event = await connection.redis_receiver.get()
             received_at = datetime.datetime.now(datetime.timezone.utc)
-            channel, msg = data
+            channel, msg = redis_event
             if channel == connection.stop_channel:
                 break
             subscription = SubscriptionName(

--- a/socketshark/receiver.py
+++ b/socketshark/receiver.py
@@ -111,12 +111,68 @@ class ServiceReceiver:
         finally:
             ping_handler.cancel()
 
+    async def _handle_service_event(
+        self,
+        session: Session,
+        data: ServiceEventData,
+        received_at: datetime.datetime,
+        queue_size: int,
+    ) -> None:
+        try:
+            await session.on_service_event(
+                data, received_at=received_at, queue_size=queue_size
+            )
+        except Exception:
+            self.shark.log.exception('unhandled exception in receiver')
+
+    def _dispatch_service_event(
+        self,
+        service_event: ServiceEventData,
+        subscription_name: SubscriptionName,
+        received_at: datetime.datetime,
+        queue_size: int,
+    ) -> list['asyncio.Task[None]']:
+        """
+        Dispatch handling the given service event.
+
+        Note that this truly *dispatches* the handling, meaning it does not
+        block till the handling is complete. That said, all asyncio Tasks are
+        returned to the caller, so the caller can await them if desired.
+        """
+        self.shark.trace_log.debug('service event', data=service_event)
+
+        # The subscription arrays may change during execution, therefore we
+        # create a snapshot before looping.
+        confirmed_sessions = list(
+            self.confirmed_subscriptions[subscription_name]
+        )
+        provisional_sessions = list(
+            self.provisional_subscriptions[subscription_name]
+        )
+        tasks = [
+            asyncio.create_task(
+                self._handle_service_event(
+                    session, service_event, received_at, queue_size
+                )
+            )
+            for session in confirmed_sessions
+        ]
+        for session in provisional_sessions:
+            self.provisional_events[session].append(service_event)
+        return tasks
+
     async def _reader_for_connection(
         self, connection: RedisConnection, once: bool = False
     ) -> bool | None:
         prefix_length = len(connection.channel_prefix)
         if once and not connection.redis_receiver._queue.qsize():
             return False
+
+        # Track in-flight tasks so we can drain them before returning.
+        # Completed tasks remove themselves via the done callback, so the set
+        # only ever contains tasks that are still running.
+        pending_tasks: set[asyncio.Task[None]] = set()
+        result: bool | None = None
 
         while True:
             queue_size = connection.redis_receiver._queue.qsize()
@@ -125,34 +181,31 @@ class ServiceReceiver:
             channel, event_json_bytes = redis_event
             if channel == connection.stop_channel:
                 break
+
             subscription_name = SubscriptionName(
                 channel.name.decode()[prefix_length:]
             )
             try:
-                data = json.loads(event_json_bytes.decode())
-                self.shark.trace_log.debug('service event', data=data)
-                # The subscription arrays may change while executing
-                # on_service_event. We therefore create a snapshot before
-                # looping.
-                confirmed_sessions = list(
-                    self.confirmed_subscriptions[subscription_name]
+                service_event = ServiceEventData(
+                    json.loads(event_json_bytes.decode())
                 )
-                provisional_sesssions = list(
-                    self.provisional_subscriptions[subscription_name]
+                tasks = self._dispatch_service_event(
+                    service_event, subscription_name, received_at, queue_size
                 )
-                for session in confirmed_sessions:
-                    await session.on_service_event(
-                        data, received_at=received_at, queue_size=queue_size
-                    )
-                for session in provisional_sesssions:
-                    self.provisional_events[session].append(data)
+                for task in tasks:
+                    pending_tasks.add(task)
+                    task.add_done_callback(pending_tasks.discard)
             except json.decoder.JSONDecodeError:
                 self.shark.log.exception('JSONDecodeError')
             except Exception:
                 self.shark.log.exception('unhandled exception in receiver')
             if once and not connection.redis_receiver._queue.qsize():
-                return True
-        return None
+                result = True
+                break
+
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks)
+        return result
 
     async def add_provisional_subscription(
         self, session: Session, subscription_name: SubscriptionName

--- a/socketshark/receiver.py
+++ b/socketshark/receiver.py
@@ -131,7 +131,7 @@ class ServiceReceiver:
             channel, msg = redis_event
             if channel == connection.stop_channel:
                 break
-            subscription = SubscriptionName(
+            subscription_name = SubscriptionName(
                 channel.name.decode()[prefix_length:]
             )
             try:
@@ -141,10 +141,10 @@ class ServiceReceiver:
                 # on_service_event. We therefore create a snapshot before
                 # looping.
                 confirmed_sessions = list(
-                    self.confirmed_subscriptions[subscription]
+                    self.confirmed_subscriptions[subscription_name]
                 )
                 provisional_sesssions = list(
-                    self.provisional_subscriptions[subscription]
+                    self.provisional_subscriptions[subscription_name]
                 )
                 for session in confirmed_sessions:
                     await session.on_service_event(
@@ -161,31 +161,31 @@ class ServiceReceiver:
         return None
 
     async def add_provisional_subscription(
-        self, session: Session, subscription: SubscriptionName
+        self, session: Session, subscription_name: SubscriptionName
     ) -> None:
-        if subscription not in self.subscriptions:
-            self.subscriptions.add(subscription)
+        if subscription_name not in self.subscriptions:
+            self.subscriptions.add(subscription_name)
             await asyncio.gather(
                 *[
                     c.redis.subscribe(
                         c.redis_receiver.channel(
-                            self._channel(c, subscription)
+                            self._channel(c, subscription_name)
                         )
                     )
                     for c in self.redis_connections
                 ]
             )
-        self.provisional_subscriptions[subscription].add(session)
+        self.provisional_subscriptions[subscription_name].add(session)
 
     async def confirm_subscription(
-        self, session: Session, subscription: SubscriptionName
+        self, session: Session, subscription_name: SubscriptionName
     ) -> None:
-        self.confirmed_subscriptions[subscription].add(session)
-        self.provisional_subscriptions[subscription].remove(session)
+        self.confirmed_subscriptions[subscription_name].add(session)
+        self.provisional_subscriptions[subscription_name].remove(session)
 
         # Clear empty set
-        if not self.provisional_subscriptions[subscription]:
-            del self.provisional_subscriptions[subscription]
+        if not self.provisional_subscriptions[subscription_name]:
+            del self.provisional_subscriptions[subscription_name]
 
         # Flush provisional messages
         events = self.provisional_events.pop(session, [])
@@ -193,26 +193,26 @@ class ServiceReceiver:
             await session.on_service_event(data)
 
     async def delete_subscription(
-        self, session: Session, subscription: SubscriptionName
+        self, session: Session, subscription_name: SubscriptionName
     ) -> None:
-        conf_set = self.confirmed_subscriptions[subscription]
+        conf_set = self.confirmed_subscriptions[subscription_name]
         conf_set.discard(session)
-        prov_set = self.provisional_subscriptions[subscription]
+        prov_set = self.provisional_subscriptions[subscription_name]
         prov_set.discard(session)
 
         # Clear empty set
         if not conf_set:
-            del self.confirmed_subscriptions[subscription]
+            del self.confirmed_subscriptions[subscription_name]
         if not prov_set:
-            del self.provisional_subscriptions[subscription]
+            del self.provisional_subscriptions[subscription_name]
 
         if not conf_set and not prov_set:
-            self.subscriptions.remove(subscription)
+            self.subscriptions.remove(subscription_name)
             await asyncio.gather(
                 *[
                     c.redis.unsubscribe(
                         c.redis_receiver.channel(
-                            self._channel(c, subscription)
+                            self._channel(c, subscription_name)
                         )
                     )
                     for c in self.redis_connections

--- a/socketshark/receiver.py
+++ b/socketshark/receiver.py
@@ -122,14 +122,14 @@ class ServiceReceiver:
             queue_size = connection.redis_receiver._queue.qsize()
             redis_event = await connection.redis_receiver.get()
             received_at = datetime.datetime.now(datetime.timezone.utc)
-            channel, msg = redis_event
+            channel, event_json_bytes = redis_event
             if channel == connection.stop_channel:
                 break
             subscription_name = SubscriptionName(
                 channel.name.decode()[prefix_length:]
             )
             try:
-                data = json.loads(msg.decode())
+                data = json.loads(event_json_bytes.decode())
                 self.shark.trace_log.debug('service event', data=data)
                 # The subscription arrays may change while executing
                 # on_service_event. We therefore create a snapshot before

--- a/socketshark/receiver.py
+++ b/socketshark/receiver.py
@@ -114,13 +114,13 @@ class ServiceReceiver:
     async def _handle_service_event(
         self,
         session: Session,
-        data: ServiceEventData,
+        service_event: ServiceEventData,
         received_at: datetime.datetime,
         queue_size: int,
     ) -> None:
         try:
             await session.on_service_event(
-                data, received_at=received_at, queue_size=queue_size
+                service_event, received_at=received_at, queue_size=queue_size
             )
         except Exception:
             self.shark.log.exception('unhandled exception in receiver')
@@ -236,8 +236,8 @@ class ServiceReceiver:
 
         # Flush provisional messages
         events = self.provisional_events.pop(session, [])
-        for data in events:
-            await session.on_service_event(data)
+        for event in events:
+            await session.on_service_event(event)
 
     async def delete_subscription(
         self, session: Session, subscription_name: SubscriptionName

--- a/socketshark/receiver.py
+++ b/socketshark/receiver.py
@@ -22,18 +22,12 @@ class ServiceReceiver:
         self.shark = shark
 
         self.subscriptions: set[SubscriptionName] = set()
-
-        # {subscription: [sessions]}
         self.provisional_subscriptions: defaultdict[
             SubscriptionName, set[Session]
         ] = defaultdict(set)
-
-        # {session: [msgs]}
         self.provisional_events: defaultdict[
             Session, list[ServiceEventData]
         ] = defaultdict(list)
-
-        # {subscription: [sessions]}
         self.confirmed_subscriptions: defaultdict[
             SubscriptionName, set[Session]
         ] = defaultdict(set)


### PR DESCRIPTION
### Problem

Prior to this PR, when processing "Service Events"[^0] we were `await`'ing each individual handling of a Service Event. In other words, the `while True: …` loop was handling **one** Service Event at a time.

This worked fine – most of the time… Until a single sending to a particularly slow / broken WebSocket connection would stall the whole loop, making subsequent Service Events slower to process than they needed to be.

### Solution

Now, we *dispatch* the processing and move on to the next Event before the previous one even finishes.

Why this is safe:
1. We still drain the backlog of pending Events in case the service is gracefully stopped.
2. We still log exceptions for Service Events' processing that failed.
3. We still return `True` if the `reader` was called with `once=True` and we've processed all the already-emitted events.

### How to review

Review the commits one by one. I included a few cleanup commits that helped me understand the code a bit better before I got around to changing it.

### PR stack

- [x] Built on top of https://github.com/closeio/socketshark/pull/352. Merge that first and then rebase this PR.

[^0]: I.e. events published by another Service into the Redis PubSub and received on the SocketShark service with the intention of passing those events along to the relevant UI clients.