### PR TITLE
[GitHub Actions] Update action versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,8 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
       - name: Install dependencies
         run: uv sync --only-group lint
       - name: Lint
@@ -37,8 +37,8 @@ jobs:
     env:
       STRICT_WARNINGS: "1"
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
Beginning on June 16th, 2026, GH action runners will begin using Node24 by default. https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

That means that we have to update the actions you use to support that node24 version. The most common ones should be updated to at least those versions:

```
actions/checkout@v6
hashicorp/vault-action@v4.0.0
actions/setup-python@6
docker/login-action@v4
docker/setup-qemu-action@v4
docker/setup-buildx-action@v4
docker/build-push-action@v7
closeio/ssh-agent@v0.10.0
aws-actions/configure-aws-credentials@v6
actions/github-script@v8
closeio/create-pull-request@v8
aws-actions/amazon-ecr-login@v2
actions/download-artifact@v8
actions/upload-artifact@v7
```
